### PR TITLE
feature: send referenced fields stats to apollo studio

### DIFF
--- a/src/ApolloTraceBuilder.ts
+++ b/src/ApolloTraceBuilder.ts
@@ -8,6 +8,7 @@ import {
 import { Trace, google } from 'apollo-reporting-protobuf'
 import { Logger } from 'apollo-server-types'
 import { defaultUsageReportingSignature } from 'apollo-graphql'
+import { ReferencedFieldsByType } from 'apollo-server-core/dist/plugin/usageReporting/referencedFields'
 
 function internalError(message: string) {
   return new Error(`[internal mercurius error] ${message}`)
@@ -22,6 +23,8 @@ export class ApolloTraceBuilder {
 
   public trace = new Trace({ root: this.rootNode })
   public startHrTime?: [number, number]
+  public referencedFieldsByType: ReferencedFieldsByType = Object.create(null)
+
   private stopped = false
   private nodes = new Map<string, Trace.Node>([
     [responsePathAsString(), this.rootNode]

--- a/src/TraceBuildersStore.ts
+++ b/src/TraceBuildersStore.ts
@@ -3,7 +3,6 @@ import os, { hostname } from 'os'
 import { FastifyInstance } from 'fastify'
 import { ReportHeader, Trace } from 'apollo-reporting-protobuf'
 import { computeCoreSchemaHash } from 'apollo-server-core/dist/plugin/schemaReporting'
-import { ReferencedFieldsByType } from 'apollo-server-core/dist/plugin/usageReporting/referencedFields'
 import { OurReport } from 'apollo-server-core/dist/plugin/usageReporting/stats'
 import { GraphQLSchema, printSchema } from 'graphql'
 import { ResponseData } from 'undici/types/dispatcher'
@@ -120,13 +119,12 @@ export function addTraceToReportAndFinishTiming(
   }
 
   report.endTime = dateToProtoTimestamp(new Date())
-  const referencedFieldsByType: ReferencedFieldsByType = Object.create(null)
   report.addTrace({
     statsReportKey: querySignature,
     trace,
     asTrace: true,
     includeTracesContributingToStats: false,
-    referencedFieldsByType
+    referencedFieldsByType: traceBuilder.referencedFieldsByType
   })
 }
 

--- a/src/TraceBuildersStore.ts
+++ b/src/TraceBuildersStore.ts
@@ -3,6 +3,7 @@ import os, { hostname } from 'os'
 import { FastifyInstance } from 'fastify'
 import { ReportHeader, Trace } from 'apollo-reporting-protobuf'
 import { computeCoreSchemaHash } from 'apollo-server-core/dist/plugin/schemaReporting'
+import { ReferencedFieldsByType } from 'apollo-server-core/dist/plugin/usageReporting/referencedFields'
 import { OurReport } from 'apollo-server-core/dist/plugin/usageReporting/stats'
 import { GraphQLSchema, printSchema } from 'graphql'
 import { ResponseData } from 'undici/types/dispatcher'
@@ -119,11 +120,13 @@ export function addTraceToReportAndFinishTiming(
   }
 
   report.endTime = dateToProtoTimestamp(new Date())
+  const referencedFieldsByType: ReferencedFieldsByType = Object.create(null)
   report.addTrace({
     statsReportKey: querySignature,
     trace,
     asTrace: true,
-    includeTracesContributingToStats: false
+    includeTracesContributingToStats: false,
+    referencedFieldsByType
   })
 }
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,6 +1,9 @@
 import tap from 'tap'
 import Fastify from 'fastify'
 import fp from 'fastify-plugin'
+import mercurius from 'mercurius'
+
+import { basicResolvers, basicSchema } from '../examples/basicSchema'
 
 import plugin from './index'
 
@@ -48,4 +51,64 @@ tap.test('plugin registration', async (t) => {
       'an Apollo Studio API key is required'
     )
   })
+})
+
+tap.test('trace store', async (t) => {
+  let app
+  t.beforeEach(async () => {
+    app = Fastify()
+    app.register(mercurius, {
+      schema: basicSchema,
+      resolvers: basicResolvers,
+      graphiql: true
+    })
+    app.register(plugin, {
+      apiKey: 'APOLLO_KEY',
+      endpointUrl: 'http://localhost:3334',
+      graphRef: 'APOLLO_GRAPH_ID' + '@' + 'APOLLO_GRAPH_VARIANT',
+      sendReportsImmediately: true
+    })
+
+    // dummy query to get trace store created
+    await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      payload: {
+        query: 'query dummyQuery { word }'
+      }
+    })
+  })
+
+  t.test(
+    'should contain trace with reference to field used in query',
+    async (tt) => {
+      const query = `
+      query testQuery {
+        post {
+          body
+        }
+      }`
+
+      // prevent from emptying the store too soon
+      app.apolloTracingStore.flushTracing = async () => null
+
+      await app.inject({
+        method: 'POST',
+        url: '/graphql',
+        payload: { query }
+      })
+
+      tt.equal(app.apolloTracingStore.traceBuilders.length, 1)
+      tt.match(app.apolloTracingStore.traceBuilders[0], {
+        referencedFieldsByType: {
+          Query: {
+            fieldNames: ['post']
+          },
+          Post: {
+            fieldNames: ['body']
+          }
+        }
+      })
+    }
+  )
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import { FastifyPluginCallback } from 'fastify'
 import fp from 'fastify-plugin'
 import 'mercurius' // needed for types
+import { calculateReferencedFieldsByType } from 'apollo-server-core/dist/plugin/usageReporting/referencedFields'
+import { getOperationAST } from 'graphql'
 
 import { ApolloTraceBuilder } from './ApolloTraceBuilder'
 import { TraceBuildersStore } from './TraceBuildersStore'
@@ -65,6 +67,12 @@ export default fp(
       traceBuilder.startTiming()
 
       context.__traceBuilder = traceBuilder
+      const operationAST = getOperationAST(document)
+      traceBuilder.referencedFieldsByType = calculateReferencedFieldsByType({
+        document: document,
+        schema: _schema,
+        resolvedOperationName: operationAST?.name?.value ?? null
+      })
       return { document }
     })
 

--- a/src/sendReport.spec.ts
+++ b/src/sendReport.spec.ts
@@ -21,6 +21,7 @@ const fakeReport = {
     '# Foo\nquery Foo { user { email pets { name } } }': {
       trace: [],
       statsWithContext: [],
+      referencedFieldsByType: {},
       internalTracesContributingToStats: []
     }
   }


### PR DESCRIPTION
Fixes needed after apollo-server-core introduced breaking change in v3.6.0