### PR TITLE
Batched queries support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ Yes this plugin works fine with them.
 
 ## Batched queries
 
-There's currently no support for batched queries. Please check [this related issue](https://github.com/nearform/mercurius-apollo-tracing/issues/125) for more information.
+Yes, this plugin supports batched queries.

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
   ],
   "peerDependencies": {
     "fastify": "4.x",
-    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
-    "mercurius": "10.x"
+    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.0.3",
@@ -57,11 +56,8 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-standard": "^5.0.0",
-    "fastify": "^4.3.0",
-    "graphql": "16.x",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
-    "mercurius": "^10.1.0",
     "nodemon": "^2.0.19",
     "prettier": "^2.7.1",
     "pretty-quick": "^3.1.3",
@@ -76,7 +72,10 @@
     "apollo-reporting-protobuf": "^3.3.2",
     "apollo-server-core": "^3.10.0",
     "apollo-server-types": "^3.6.2",
+    "fastify": "4.x",
     "fastify-plugin": "^4.0.0",
+    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+    "mercurius": "^10.5.1",
     "undici": "^5.8.0"
   },
   "engines": {

--- a/src/indexWithBatching.spec.ts
+++ b/src/indexWithBatching.spec.ts
@@ -1,0 +1,94 @@
+import tap from 'tap'
+import Fastify from 'fastify'
+import mercurius from 'mercurius'
+
+import { basicResolvers, basicSchema } from '../examples/basicSchema'
+
+import plugin from './index'
+
+tap.test('trace store with batching', async (t) => {
+  let app
+
+  t.beforeEach(async () => {
+    app = Fastify()
+    await app.register(mercurius, {
+      schema: basicSchema,
+      resolvers: basicResolvers,
+      allowBatchedQueries: true,
+      graphiql: true
+    })
+    await app.register(plugin, {
+      apiKey: 'APOLLO_KEY',
+      endpointUrl: 'http://localhost:3334',
+      graphRef: 'APOLLO_GRAPH_ID' + '@' + 'APOLLO_GRAPH_VARIANT',
+      sendReportsImmediately: true
+    })
+
+    // dummy query to get trace store created
+    await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      payload: {
+        query: 'query dummyQuery { word }'
+      }
+    })
+  })
+
+  t.test(
+    'should contain two traces with references to fields used in each query operation',
+    async (tt) => {
+      // prevent from emptying the store too soon
+      app.apolloTracingStore.flushTracing = async () => null
+
+      await app.inject({
+        method: 'POST',
+        url: '/graphql',
+        body: [
+          {
+            operationName: 'FirstQuery',
+            query: `query FirstQuery {
+              post {
+                title
+              }
+            }`
+          },
+          {
+            operationName: 'SecondQuery',
+            query: `query SecondQuery {
+              post {
+                body
+              }
+            }`
+          }
+        ]
+      })
+
+      tt.match(app.apolloTracingStore.traceBuilders, [
+        {
+          querySignature: '# -\nquery FirstQuery{post{title}}',
+          referencedFieldsByType: {
+            Query: {
+              fieldNames: ['post']
+            },
+            Post: {
+              fieldNames: ['title']
+            }
+          },
+          stopped: true
+        },
+        {
+          querySignature: '# -\nquery SecondQuery{post{body}}',
+          referencedFieldsByType: {
+            Query: {
+              fieldNames: ['post']
+            },
+            Post: {
+              fieldNames: ['body']
+            }
+          },
+          stopped: true
+        }
+      ])
+    }
+  )
+})


### PR DESCRIPTION
fixes #125 

- Bump Mercurius to v10.5.1 which enables batched queries support by creating individual contexts for each query operation
- Add tests for batched queries support