### PR TITLE
Fixed error caused by subscriptions

### DIFF
--- a/examples/subscriptionSchema.ts
+++ b/examples/subscriptionSchema.ts
@@ -1,0 +1,52 @@
+let idCount = 1
+
+const notifications = [
+  {
+    id: idCount,
+    message: 'Notification message'
+  }
+]
+
+export const schema = `
+type Notification {
+  id: ID!
+  message: String
+}
+type Query {
+  notifications: [Notification]
+}
+type Mutation {
+  addNotification(message: String): Notification
+}
+type Subscription {
+  notificationAdded: Notification
+}
+`
+
+export const resolvers = {
+  Query: {
+    notifications: () => notifications
+  },
+  Mutation: {
+    addNotification: async (_, { message }, { pubsub }) => {
+      const id = idCount++
+      const notification = {
+        id,
+        message
+      }
+      await pubsub.publish({
+        topic: 'NOTIFICATION_ADDED',
+        payload: {
+          notificationAdded: notification
+        }
+      })
+
+      return notification
+    }
+  },
+  Subscription: {
+    notificationAdded: {
+      subscribe: (_, __, { pubsub }) => pubsub.subscribe('NOTIFICATION_ADDED')
+    }
+  }
+}

--- a/src/hookIntoSchemaResolvers.ts
+++ b/src/hookIntoSchemaResolvers.ts
@@ -17,7 +17,7 @@ export function hookIntoSchemaResolvers(schema: GraphQLSchema): void {
           field.resolve = (self, arg, ctx, info) => {
             const operationName = info.operation.name?.value
 
-            if (operationName === 'IntrospectionQuery') {
+            if (operationName === 'IntrospectionQuery' || !ctx.__traceBuilder) {
               return originalFieldResolver(self, arg, ctx, info)
             }
             const traceBuilder: ApolloTraceBuilder = ctx.__traceBuilder

--- a/src/subscriptions.spec.ts
+++ b/src/subscriptions.spec.ts
@@ -1,0 +1,144 @@
+import { promisify } from 'util'
+
+import tap from 'tap'
+import fastify from 'fastify'
+import mercurius from 'mercurius'
+import WebSocket from 'ws'
+
+import { resolvers, schema } from '../examples/subscriptionSchema'
+
+import plugin from './index'
+
+const sleep = promisify(setTimeout)
+
+tap.test(
+  'metrics are reported when client is using subscription',
+  async (t) => {
+    const app = fastify()
+    t.plan(2)
+
+    app.register(mercurius, {
+      schema,
+      resolvers,
+      subscription: {
+        keepAlive: 1000
+      }
+    })
+
+    await app.register(plugin, {
+      apiKey: 'APOLLO_KEY',
+      endpointUrl: 'http://localhost:3334',
+      graphRef: 'APOLLO_GRAPH_ID' + '@' + 'APOLLO_GRAPH_VARIANT',
+      sendReportsImmediately: true
+    })
+
+    await app.listen({ port: 0 })
+
+    const ws = new WebSocket(
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      'ws://localhost:' + app.server.address().port + '/graphql',
+      'graphql-ws'
+    )
+    const client = WebSocket.createWebSocketStream(ws, {
+      encoding: 'utf8',
+      objectMode: true
+    })
+
+    t.teardown(client.destroy.bind(client))
+
+    client.write(
+      JSON.stringify({
+        type: 'connection_init'
+      })
+    )
+
+    client.write(
+      JSON.stringify({
+        id: 1,
+        type: 'start',
+        payload: {
+          query: `
+            subscription {
+              notificationAdded {
+                id
+                message
+              }
+            }
+          `
+        }
+      })
+    )
+
+    client.write(
+      JSON.stringify({
+        id: 2,
+        type: 'start',
+        payload: {
+          query: `
+            subscription {
+              notificationAdded {
+                id
+                message
+              }
+            }
+          `
+        }
+      })
+    )
+
+    client.write(
+      JSON.stringify({
+        id: 2,
+        type: 'stop'
+      })
+    )
+
+    app.apolloTracingStore.flushTracing = async () => null
+
+    client.on('data', (chunk) => {
+      const data = JSON.parse(chunk)
+
+      if (data.type === 'data') {
+        t.equal(
+          chunk,
+          JSON.stringify({
+            type: 'data',
+            id: 1,
+            payload: {
+              data: {
+                notificationAdded: {
+                  id: '1',
+                  message: 'Hello World'
+                }
+              }
+            }
+          })
+        )
+        t.equal(
+          app.apolloTracingStore.traceBuilders[0].querySignature,
+          `# -\nmutation{addNotification(message:""){id}}`
+        )
+        app.close()
+        client.end()
+        t.end()
+      } else if (data.type === 'complete') {
+        app.inject({
+          method: 'POST',
+          url: '/graphql',
+          payload: {
+            query: `
+                mutation {
+                  addNotification(message: "Hello World") {
+                    id
+                  }
+                }
+              `
+          }
+        })
+      }
+    })
+
+    await sleep(1000)
+  }
+)


### PR DESCRIPTION
This PR fixes an issue with the plugin when a client is consuming a subscription.

The problem was that the `traceBuilder` was not being attached in case of subscription queries since they are not captured in the `preExecution` hook. This caused the plugin to break.

closes  #135 