### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx commitlint --edit 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "eslint-plugin-standard": "^5.0.0",
         "fastify": "^4.3.0",
         "graphql": "16.x",
-        "husky": "^9.0.7",
+        "husky": "^9.0.11",
         "lint-staged": "^15.0.1",
         "mercurius": "^14.0.0",
         "nodemon": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-standard": "^5.0.0",
     "fastify": "^4.3.0",
     "graphql": "16.x",
-    "husky": "^9.0.7",
+    "husky": "^9.0.11",
     "lint-staged": "^15.0.1",
     "mercurius": "^14.0.0",
     "nodemon": "^3.0.1",


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)