### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/nearform/mercurius-apollo-tracing"
   },
   "scripts": {
-    "prepare": "tsc && husky install",
+    "prepare": "tsc && husky",
     "build": "tsc",
     "test": "NODE_ENV=test TAP_SNAPSHOT=1 tap --disable-coverage --allow-empty-coverage --jobs=1",
     "lint": "eslint .",


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)